### PR TITLE
Add osmcha link to new user announcements

### DIFF
--- a/announce_new_users.py
+++ b/announce_new_users.py
@@ -62,11 +62,13 @@ for feature in reversed(features):
 
         send_to_slack(
             u"`<https://www.openstreetmap.org/user/{}|{}>` just made "
-            "their <https://www.openstreetmap.org/changeset/{}|first edit>{}".format(
+            "their <https://www.openstreetmap.org/changeset/{}|first edit>{}"
+            " (<https://osmcha.mapbox.com/changesets/{}|OSMCha>)".format(
                 props.get('user').get('name'),
                 props.get('user').get('name'),
                 props.get('changeset').get('id'),
                 location_str,
+                props.get('changeset').get('id'),
             )
         )
 


### PR DESCRIPTION
This adds a link to OSMCha to the end of the new user announcement message..